### PR TITLE
Unnecessary unsafe cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an NES emulator and a work in progress. The CPU and PPU work, though the
 
 - One dependency (SDL)
 
-- Zero lines of `unsafe` in nestur
+- Zero lines of `unsafe` in nestur itself
 
 - NTSC timing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an NES emulator and a work in progress. The CPU and PPU work, though the
 
 - One dependency (SDL)
 
-- One line of `unsafe` (`std::mem::transmute::<u8>() -> i8`)
+- Zero lines of `unsafe` in nestur
 
 - NTSC timing
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,6 @@
 extern crate sdl2;
 
-use sdl2::audio::{AudioSpecDesired};
+use sdl2::audio::AudioSpecDesired;
 
 pub fn initialize(context: &sdl2::Sdl) -> Result<sdl2::audio::AudioQueue<f32>, String> {
     let audio_subsystem = context.audio()?;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,6 @@
 extern crate sdl2;
 
-use sdl2::audio::{AudioCallback, AudioSpecDesired};
+use sdl2::audio::{AudioSpecDesired};
 
 pub fn initialize(context: &sdl2::Sdl) -> Result<sdl2::audio::AudioQueue<f32>, String> {
     let audio_subsystem = context.audio()?;

--- a/src/cpu/utility.rs
+++ b/src/cpu/utility.rs
@@ -95,5 +95,5 @@ impl super::Cpu {
 }
 
 pub fn u8_to_i8(offset: u8) -> i8 {
-    unsafe { std::mem::transmute(offset) }
+    offset as i8
 }


### PR DESCRIPTION
`as` and `transmute` appear to be equivalent.

This program prints nothing:

```

pub fn u8_to_i8(offset: u8) -> i8 {
    offset as i8
}

pub fn u8_to_i8_unsafe(offset: u8) -> i8 {
    unsafe { std::mem::transmute(offset) }
}

pub fn i8_to_u8(val: i8) -> u8 {
    val as u8
}

pub fn i8_to_u8_unsafe(val: i8) -> u8 {
    unsafe { std::mem::transmute(val) }
}

fn main() {
    for n in 0..=255 {
        let as_conv = u8_to_i8(n);
        let transmuted = u8_to_i8_unsafe(n);
        if as_conv != transmuted {
            println!("{} {}", as_conv, transmuted);
        }
    }
    for n in -128..=127 {
        let as_conv = i8_to_u8(n);
        let transmuted = i8_to_u8_unsafe(n);
        if as_conv != transmuted {
            println!("{} {}", as_conv, transmuted);
        }
    }
}
```