### PR TITLE
Remove mutability from Mapper get_mirroring

### DIFF
--- a/src/cartridge/cnrom.rs
+++ b/src/cartridge/cnrom.rs
@@ -33,7 +33,7 @@ impl Mapper for Cnrom {
         }
     }
 
-    fn get_mirroring(&mut self) -> Mirror {
+    fn get_mirroring(&self) -> Mirror {
         self.cart.mirroring
     }
 

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -175,7 +175,7 @@ impl Mapper for Mmc1 {
         }
     }
 
-    fn get_mirroring(&mut self) -> Mirror {
+    fn get_mirroring(&self) -> Mirror {
         self.mirroring
     }
 

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -175,7 +175,7 @@ impl Mapper for Mmc3 {
         }
     }
 
-    fn get_mirroring(&mut self) -> Mirror {
+    fn get_mirroring(&self) -> Mirror {
         if self.cart.four_screen_vram {
             Mirror::FourScreen
         } else {

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -17,7 +17,7 @@ use std::io::Read;
 pub trait Mapper {
     fn read(&self, address: usize) -> u8;
     fn write(&mut self, address: usize, value: u8);
-    fn get_mirroring(&mut self) -> Mirror;
+    fn get_mirroring(&self) -> Mirror;
     fn load_battery_backed_ram(&mut self);
     fn save_battery_backed_ram(&self);
     fn clock(&mut self);

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -49,7 +49,7 @@ impl Mapper for Nrom {
         }
     }
 
-    fn get_mirroring(&mut self) -> Mirror {
+    fn get_mirroring(&self) -> Mirror {
         self.cart.mirroring
     }
 

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -44,7 +44,7 @@ impl Mapper for Uxrom {
         }
     }
 
-    fn get_mirroring(&mut self) -> Mirror {
+    fn get_mirroring(&self) -> Mirror {
         self.cart.mirroring
     }
 

--- a/src/ppu/memory.rs
+++ b/src/ppu/memory.rs
@@ -53,7 +53,7 @@ impl super::Ppu {
     fn read_nametable(&mut self, address: usize) -> u8 {
         let base = address % 0x1000;
         let offset = base % 0x0400;
-        match self.mapper.borrow_mut().get_mirroring() {
+        match self.mapper.borrow().get_mirroring() {
             Mirror::LowBank => self.nametable_A[offset],
             Mirror::HighBank => self.nametable_B[offset],
             Mirror::Horizontal => {
@@ -85,7 +85,7 @@ impl super::Ppu {
     fn write_nametable(&mut self, address: usize, value: u8) {
         let base = address % 0x1000;
         let offset = base % 0x0400;
-        match self.mapper.borrow_mut().get_mirroring() {
+        match self.mapper.borrow().get_mirroring() {
             Mirror::LowBank => self.nametable_A[offset] = value,
             Mirror::HighBank => self.nametable_B[offset] = value,
             Mirror::Horizontal => {


### PR DESCRIPTION
Minor tweak to Mapper interface to eliminate unnecessary mutability.